### PR TITLE
Fixed query in sfCategoryHandler::getSubCats().

### DIFF
--- a/class/category.php
+++ b/class/category.php
@@ -635,7 +635,7 @@ class sfCategoryHandler extends XoopsObjectHandler
      */
     public function getSubCats($categories)
     {
-        $criteria = new CriteriaCompo(new Criteria('parentid', '(' . implode(',', array_keys($categories)) . ')'), 'IN');
+        $criteria = new CriteriaCompo(new Criteria('parentid', '(' . implode(',', array_keys($categories)) . ')', 'IN'));
         $ret      = array();
         if (!sf_userIsAdmin()) {
             $smartPermHandler = xoops_getModuleHandler('permission', 'smartfaq');


### PR DESCRIPTION
This ensures `'IN'` is treated as the third parameter in the `new Criteria()` call, rather than the second parameter in the `new CriteriaCompo()` call.

Without this change, the criteria results in SQL containing:
``WHERE (`parentid` = '(1,2,3,4)')``

With this change, it will be:
``WHERE (`parentid` IN (1,2,3,4))``
