### PR TITLE
Removed attempt to call count() on mysqli_result.

### DIFF
--- a/class/faq.php
+++ b/class/faq.php
@@ -885,10 +885,6 @@ class sfFaqHandler extends XoopsObjectHandler
             return false;
         }
 
-        if (count($result) == 0) {
-            return false;
-        }
-
         while ($myrow = $this->db->fetchArray($result)) {
             $faq = new sfFaq();
             $faq->assignVars($myrow);


### PR DESCRIPTION
This avoids "Warning: count(): Parameter must be an array or an object that implements Countable in file /modules/smartfaq/class/faq.php line 888" and otherwise functions the same (since the if-statement's condition is never met).